### PR TITLE
[gallery] feat: fetchPosts.js 개선 및 검색, 정렬 필터 매니징 클래스 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,11 @@
         </ul>
       </nav>
     </header>
+    <section id="filter" class="flex gap-x-2"></section>
+    <button id="clearFilters">Clear Filters</button>
     <main></main>
     <footer></footer>
+
     <script type="module" src="./src/js/main.js"></script>
   </body>
 </html>

--- a/src/js/constants/filterList.js
+++ b/src/js/constants/filterList.js
@@ -1,0 +1,21 @@
+export const filterButtons = [
+  {
+    id: "filterDjango",
+    param: "search",
+    value: "user",
+    text: "user로 검색",
+  },
+  {
+    id: "sortTitleDesc",
+    param: "sortBy",
+    value: "title",
+    text: "내림차순",
+  },
+
+  {
+    id: "filterBlogCategory",
+    param: "category",
+    value: "Blog",
+    text: "블로그만",
+  },
+];

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,5 +1,7 @@
 import { initializeTheme } from "./util/initializeTheme.js";
 
+import { filterButtons } from "./constants/filterList.js";
+import MainFilterManager from "./service/MainFilterManager.js";
 import { fetchPosts } from "./util/fetchPost.js";
 import { applySavedTheme } from "./util/toggleTheme.js";
 import { createPostDetailView } from "./views/postDetailView.js";
@@ -32,7 +34,7 @@ async function renderMainContent() {
       postSection.addEventListener("click", (event) => {
         if (event.target.tagName === "A" && event.target.dataset.id) {
           const postId = event.target.dataset.id;
-          // console.log(postId);
+
           renderPostDetail(posts[parseInt(postId) - 1].fileName);
         }
       });
@@ -40,6 +42,7 @@ async function renderMainContent() {
     });
 
     main.innerHTML = "";
+
     postSections.forEach((section) => main.appendChild(section));
   } catch (error) {
     console.error(
@@ -60,3 +63,25 @@ applySavedTheme();
 
 initializeTheme();
 renderMainContent();
+
+document.addEventListener("DOMContentLoaded", () => {
+  const mainFilterManager = new MainFilterManager(renderMainContent);
+
+  const filterContainer = document.getElementById("filter");
+
+  filterButtons.forEach((button) => {
+    const btn = document.createElement("button");
+    btn.classList.add("bg-gray-200", "hover:bg-gray-300", "rounded-md", "p-2");
+    btn.id = button.id;
+    btn.textContent = button.text;
+    filterContainer.appendChild(btn);
+
+    mainFilterManager.addFilter(button.id, button.param, button.value);
+  });
+
+  document.getElementById("clearFilters").addEventListener("click", () => {
+    mainFilterManager.clearFilters();
+  });
+
+  renderMainContent();
+});

--- a/src/js/service/FilterManager.js
+++ b/src/js/service/FilterManager.js
@@ -1,0 +1,60 @@
+/**
+ * URL의 쿼리 파라미터를 관리하는 클래스입니다.
+ * @class
+ */
+export default class FilterManager {
+  /**
+   * FilterManager 클래스의 새 인스턴스를 생성합니다.
+   * @constructor
+   */
+  constructor() {
+    this.filters = new Map();
+    this.currentFilters = new URLSearchParams(window.location.search);
+  }
+
+  /**
+   * 새 필터를 추가합니다.
+   * @method
+   * @param {string} buttonId - 필터를 활성화하는 버튼의 ID입니다.
+   * @param {string} param - 필터의 파라미터 이름입니다.
+   * @param {string} value - 필터의 파라미터 값입니다.
+   */
+  addFilter(buttonId, param, value) {
+    this.filters.set(buttonId, { param, value });
+
+    document.getElementById(buttonId).addEventListener("click", () => {
+      if (this.currentFilters.get(param) === value) {
+        this.currentFilters.delete(param);
+      } else {
+        // 동일한 param에 대해 다른 버튼을 클릭할 경우, 이전 값을 제거합니다.
+        this.filters.forEach((filter, key) => {
+          if (filter.param === param) {
+            this.currentFilters.delete(param);
+          }
+        });
+        this.currentFilters.set(param, value);
+      }
+
+      this.updateURL();
+    });
+  }
+
+  /**
+   * 모든 필터를 제거합니다.
+   * @method
+   */
+  clearFilters() {
+    this.currentFilters = new URLSearchParams();
+    this.updateURL();
+  }
+
+  /**
+   * URL의 쿼리 문자열을 현재 필터에 맞게 업데이트합니다.
+   * @method
+   */
+  updateURL() {
+    const url = new URL(window.location);
+    url.search = this.currentFilters.toString();
+    window.history.pushState({}, "", url.toString());
+  }
+}

--- a/src/js/service/MainFilterManager.js
+++ b/src/js/service/MainFilterManager.js
@@ -1,0 +1,51 @@
+import FilterManager from "./FilterManager.js";
+
+/**
+ * FilterManager 클래스를 확장하여 렌더링 콜백과 활성 필터 하이라이팅 기능을 추가하는 클래스입니다.
+ * @class
+ * @extends FilterManager
+ */
+export default class MainFilterManager extends FilterManager {
+  /**
+   * MainFilterManager 클래스의 새 인스턴스를 생성합니다.
+   * @constructor
+   * @param {Function} renderCallback - 콘텐츠를 렌더링하는 콜백 함수입니다.
+   */
+  constructor(renderCallback) {
+    super();
+    this.renderCallback = renderCallback;
+
+    window.addEventListener("popstate", () => {
+      this.renderCallback();
+    });
+  }
+
+  /**
+   * 현재 활성화된 필터에 대응하는 버튼을 하이라이트합니다.
+   * @method
+   */
+  highlightActiveFilters() {
+    this.filters.forEach((value, key) => {
+      const button = document.getElementById(key);
+      if (button) {
+        if (this.currentFilters.get(value.param) === value.value) {
+          button.classList.add("bg-blue-500", "text-white");
+          button.classList.remove("bg-gray-200", "hover:bg-gray-300");
+        } else {
+          button.classList.add("bg-gray-200", "hover:bg-gray-300");
+          button.classList.remove("bg-blue-500", "text-white");
+        }
+      }
+    });
+  }
+
+  /**
+   * URL의 쿼리 문자열을 현재 필터에 맞게 업데이트하고, 콘텐츠를 렌더링하고, 활성 필터를 하이라이트합니다.
+   * @method
+   */
+  updateURL() {
+    super.updateURL();
+    this.renderCallback();
+    this.highlightActiveFilters();
+  }
+}

--- a/src/js/util/fetchPost.js
+++ b/src/js/util/fetchPost.js
@@ -1,7 +1,61 @@
+/**
+ * URL의 쿼리 파라미터를 기반으로 게시물 목록을 가져옵니다.
+ * 검색 쿼리, 정렬 방식, 정렬 방향, 카테고리 필터링을 지원합니다.
+ *
+ * @async
+ * @function
+ * @param {string} [search] - 검색 쿼리. 제목이나 태그가 이 쿼리를 포함하는 게시물만 반환합니다.
+ * @param {string} [sortBy=date] - 정렬 방식. 이 속성에 따라 게시물을 정렬합니다.
+ * @param {string} [sortDirection=asc] - 정렬 방향. 'asc' 또는 'desc'를 지정할 수 있습니다.
+ * @param {string} [category] - 카테고리 필터. 이 카테고리의 게시물만 반환합니다.
+ * @returns {Promise<Array>} 게시물 목록을 포함하는 프로미스. 각 게시물은 title, tags, category 등의 속성을 가진 객체입니다.
+ * @throws {Error} 데이터를 가져오는 데 실패하면 오류를 발생시킵니다.
+ *
+ * @example
+ * fetchPosts().then(posts => console.log(posts)).catch(error => console.error(error));
+ */
 export async function fetchPosts() {
-    const response = await fetch(`${window.location.origin}/src/postsList/postsList.json`);
-    if (!response.ok) {
-        throw new Error('데이터를 가져오는데 실패했습니다.');
+  // URL에서 쿼리 파라미터 읽기
+  const params = new URLSearchParams(window.location.search);
+  const searchQuery = params.get("search") || "";
+  const sortBy = params.get("sortBy") || "date";
+  const sortDirection = params.get("sortDirection") || "asc";
+  const filterCategory = params.get("category") || "";
+
+  const response = await fetch(
+    `${window.location.origin}/src/postsList/postsList.json`
+  );
+  if (!response.ok) {
+    throw new Error("데이터를 가져오는데 실패했습니다.");
+  }
+  let posts = await response.json();
+
+  // 검색 쿼리에 따라 필터링
+  if (searchQuery) {
+    posts = posts.filter(
+      (post) =>
+        post.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        post.tags.some((tag) =>
+          tag.toLowerCase().includes(searchQuery.toLowerCase())
+        )
+    );
+  }
+
+  // 카테고리에 따라 필터링
+  if (filterCategory) {
+    posts = posts.filter((post) => post.category === filterCategory);
+  }
+
+  // 정렬
+  posts.sort((a, b) => {
+    let comparison = 0;
+    if (a[sortBy] < b[sortBy]) {
+      comparison = -1;
+    } else if (a[sortBy] > b[sortBy]) {
+      comparison = 1;
     }
-    return await response.json();
+    return sortDirection === "asc" ? comparison : comparison * -1;
+  });
+
+  return posts;
 }


### PR DESCRIPTION
- fetchPosts.js 개선
  - 검색 및 정렬 기능 추가
  - 쿼리 파라미터를 사용해서 새로고침이나 뒤로가기 시에도 검색 및 정렬을 유지하게 제작
 
- FilterManager.js 추가
  - 필터를 관리하기 위한 기본 클래스
  -  history API를 사용합니다.
 
- MainFilterManager.js 추가
  - main.js에 결합하여 컨텐츠를 재렌더링하기 위한 extended 클래스
  - history API를 사용하며, popState를 읽어서 renderCallback을 실행합니다.
  - 간단한 버튼 토글 스타일이 포함되어 있습니다(임시).
 
- main.js와 index.html에 예시 코드 추가
  - index.html에 id="filter" 를 가진 section 과 clear filter 버튼 추가
  - main.js에서 MainFilterManager 실행코드 추가
  -  constants 폴더를 만들어서 filterList를 상수로 따로 관리합니다.
  - console.log 제거
 
- jsDoc으로 주석 추가
  - 여러 사람이 쓸거 같아서 fetchPosts 및 filterManager에 주석을 추가해두었습니다.
