### PR TITLE
[gallery] ✨feat: Tab형 Django model Editor 추가, DetailView 스타일

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,3 +15,24 @@ body,
 .CodeMirror-scroll {
   -ms-overflow-style: none; /* 스크롤바를 숨깁니다 */
 }
+
+.tab-container {
+  display: flex;
+  margin-bottom: 10px;
+}
+
+.tab-button {
+  padding: 5px 10px;
+  margin-right: 5px;
+  background-color: #f1f1f1;
+  border: none;
+  cursor: pointer;
+}
+
+.tab-button.active {
+  background-color: #ccc;
+}
+
+.editor-container {
+  border: 1px solid #ccc;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,21 +1,43 @@
 /* Chrome, Safari, Opera 등의 Webkit 브라우저용 */
-body ::-webkit-scrollbar,
+body::-webkit-scrollbar,
 .CodeMirror-scroll::-webkit-scrollbar {
-  display: none; /* 스크롤바를 숨깁니다 */
+  width: 10px;
+}
+
+body::-webkit-scrollbar-track,
+.CodeMirror-scroll::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+body::-webkit-scrollbar-thumb,
+.CodeMirror-scroll::-webkit-scrollbar-thumb {
+  background: #888;
+}
+
+body::-webkit-scrollbar-thumb:hover,
+.CodeMirror-scroll::-webkit-scrollbar-thumb:hover {
+  background: #555;
 }
 
 /* Firefox 브라우저용 */
-body,
+body {
+  scrollbar-width: thin;
+  scrollbar-color: #888 #f1f1f1;
+}
+
 .CodeMirror-scroll {
-  scrollbar-width: none; /* 스크롤바를 숨깁니다 */
+  scrollbar-width: thin;
+  scrollbar-color: #888 #f1f1f1;
 }
 
 /* IE 10+ 및 Edge 브라우저용 */
-body,
-.CodeMirror-scroll {
-  -ms-overflow-style: none; /* 스크롤바를 숨깁니다 */
+body {
+  -ms-overflow-style: scrollbar;
 }
 
+.CodeMirror-scroll {
+  -ms-overflow-style: scrollbar;
+}
 .tab-container {
   display: flex;
   margin-bottom: 10px;

--- a/src/js/service/CodeMirrorEditor.js
+++ b/src/js/service/CodeMirrorEditor.js
@@ -1,11 +1,13 @@
 import { mermaidMode } from "../lib/codemirror/mermaidMode.js";
 
 export default class CodeMirrorEditor {
-  constructor(selector, initialValue = "") {
+  constructor(selector, initialValue = "", readOnly = false) {
     this.selector = selector;
     this.initialValue = initialValue;
     this.editor = null;
+    this.readOnly = readOnly;
   }
+
   async loadCodeMirror() {
     return new Promise((resolve, reject) => {
       const link = document.createElement("link");
@@ -25,18 +27,29 @@ export default class CodeMirrorEditor {
         "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.59.4/codemirror.min.js";
       script.onload = () => {
         mermaidMode(CodeMirror);
-        const markdownScript = document.createElement("script");
-        markdownScript.src =
-          "https://cdn.jsdelivr.net/npm/codemirror@5.63.3/mode/markdown/markdown.min.js";
-        markdownScript.onload = () => {
-          console.log("CodeMirror loaded");
-          resolve();
+
+        const pythonScript = document.createElement("script");
+        pythonScript.src =
+          "https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/mode/python/python.min.js";
+        pythonScript.onload = () => {
+          const markdownScript = document.createElement("script");
+          markdownScript.src =
+            "https://cdn.jsdelivr.net/npm/codemirror@5.63.3/mode/markdown/markdown.min.js";
+          markdownScript.onload = () => {
+            console.log("CodeMirror loaded");
+            resolve();
+          };
+          markdownScript.onerror = (e) => {
+            console.error("Error loading CodeMirror markdown mode:", e);
+            reject(e);
+          };
+          document.body.appendChild(markdownScript);
         };
-        markdownScript.onerror = (e) => {
-          console.error("Error loading CodeMirror markdown mode:", e);
+        pythonScript.onerror = (e) => {
+          console.error("Error loading CodeMirror python mode:", e);
           reject(e);
         };
-        document.body.appendChild(markdownScript);
+        document.body.appendChild(pythonScript);
       };
       script.onerror = (e) => {
         console.error("Error loading CodeMirror:", e);
@@ -45,6 +58,7 @@ export default class CodeMirrorEditor {
       document.body.appendChild(script);
     });
   }
+
   async initialize() {
     try {
       await this.loadCodeMirror();

--- a/src/js/service/DjangoCodeBlocksEditor.js
+++ b/src/js/service/DjangoCodeBlocksEditor.js
@@ -1,0 +1,72 @@
+import CodeMirrorEditor from "./CodeMirrorEditor.js";
+
+export default class DjangoCodeBlocksEditor extends CodeMirrorEditor {
+  constructor(selector, djangoCodeBlocks = [], readOnly = false) {
+    super(selector, "", readOnly);
+    this.djangoCodeBlocks = djangoCodeBlocks;
+  }
+
+  async initialize() {
+    try {
+      await this.loadCodeMirror();
+      const CodemirrorContainer = document.querySelector(this.selector);
+      if (CodemirrorContainer) {
+        // 탭 컨테이너 생성
+        const tabContainer = document.createElement("div");
+        tabContainer.classList.add("tab-container");
+
+        // 코드 에디터 컨테이너 생성
+        const editorContainer = document.createElement("div");
+        editorContainer.classList.add("editor-container");
+
+        // 탭 버튼 생성 및 클릭 이벤트 설정
+        this.djangoCodeBlocks.forEach((block, index) => {
+          const tabButton = document.createElement("button");
+          tabButton.textContent = block.name;
+          tabButton.classList.add("tab-button");
+          tabButton.addEventListener("click", () => {
+            this.setActiveTab(index);
+          });
+          tabContainer.appendChild(tabButton);
+        });
+
+        // 코드 에디터 생성
+        this.editor = CodeMirror(editorContainer, {
+          lineNumbers: true,
+          mode: "python",
+          theme: "dracula",
+          readOnly: this.readOnly,
+        });
+
+        // 초기 코드 블록 설정
+        if (this.djangoCodeBlocks.length > 0) {
+          this.setActiveTab(0);
+          this.editor.setValue(this.djangoCodeBlocks[0].code);
+          tabContainer.firstChild.classList.add("active");
+        }
+
+        CodemirrorContainer.appendChild(tabContainer);
+        CodemirrorContainer.appendChild(editorContainer);
+
+        // 에디터 새로고침
+        this.editor.refresh();
+      } else {
+        console.error("Container for CodeMirror not found:", this.selector);
+      }
+    } catch (e) {
+      console.error("Error initializing CodeMirror:", e);
+    }
+  }
+
+  setActiveTab(index) {
+    const tabButtons = document.querySelectorAll(".tab-button");
+    tabButtons.forEach((button, i) => {
+      if (i === index) {
+        button.classList.add("active");
+        this.setValue(this.djangoCodeBlocks[i].code);
+      } else {
+        button.classList.remove("active");
+      }
+    });
+  }
+}

--- a/src/js/views/postDetailView.js
+++ b/src/js/views/postDetailView.js
@@ -45,21 +45,29 @@ async function createPostDetailElement(
     contributorProfile +
     `
  
-    <section class="flex relative w-full">
-      <article class="prose prose-2xl mx-auto w-full px-6 pt-10">${htmlContent}</article>
-      <div class="viz-placeholder"></div>
-    
-      
-    </section>
-    <Textarea class="language-viz"></Textarea>
-    <section class="mermaid">
+    <section class="flex flex-col md:flex-row w-full h-lvh items-center justify-center">
+      <article class="prose 2xl:prose-xl w-full md:w-1/2 h-full overflow-y-auto px-10 pt-5">${htmlContent}</article>
 
+
+      <div class="flex flex-col relative">
+    
+      <div class="django-container w-full">
+     
+    
+      </div>
+
+      <div class="viz-image-holder"></div>
+      </div>
+    </section>
+   
+   
+    <section class="mermaid">
+    <Textarea class="language-viz"></Textarea>
         ${mermaidCodeBlocks} <button class="absolute right-10" id="resetZoom">Reset Zoom</button>
         <button class="absolute right-10 top-10" id="downloadSVG" data-format="svg">Download SVG</button>
       </section>
 
-      <div class="django-container">
-      </div>
+  
  
   `;
 
@@ -69,7 +77,7 @@ async function createPostDetailElement(
     scale: 2,
   });
 
-  const ERDBlock = postDetailSection.querySelector(".viz-placeholder");
+  const ERDBlock = postDetailSection.querySelector(".viz-image-holder");
   ERDBlock.innerHTML = svgString;
 
   const models = new DjangoCodeBlocksEditor(
@@ -92,7 +100,7 @@ async function createPostDetailElement(
           const svgString = await vizRenderer.renderSVG(currentValue, {
             scale: 2,
           });
-          document.querySelector(".viz-placeholder").innerHTML = svgString;
+          document.querySelector(".viz-image-holder").innerHTML = svgString;
         } catch (error) {
           console.error("Viz rendering error:", error);
         }

--- a/src/js/views/postDetailView.js
+++ b/src/js/views/postDetailView.js
@@ -1,5 +1,6 @@
 import { getContributorProfile } from "../components/ContributorProfile.js";
 import CodeMirrorEditor from "../service/CodeMirrorEditor.js";
+import DjangoCodeBlocksEditor from "../service/DjangoCodeBlocksEditor.js";
 import VizRenderer from "../service/VizRenderer.js";
 import { fetchPostDetail } from "../util/fetchPostDetail.js";
 import { parseMarkdown } from "../util/markdownParser.js";
@@ -8,14 +9,18 @@ import { throttle } from "../util/throttle.js";
 export async function createPostDetailView(fileName) {
   try {
     const { markdownContent, postDetail } = await fetchPostDetail(fileName);
-    const { htmlContent, mermaidCodeBlocks, vizCodeBlocks } =
+    const { htmlContent, mermaidCodeBlocks, vizCodeBlocks, djangoCodeBlocks } =
       parseMarkdown(markdownContent);
-
+    console.log(
+      "🚀 ~ createPostDetailView ~ djangoCodeBlocks:",
+      djangoCodeBlocks,
+    );
     const postDetailSection = createPostDetailElement(
       htmlContent,
       postDetail,
       mermaidCodeBlocks.join("\n"),
       vizCodeBlocks,
+      djangoCodeBlocks,
     );
     postDetailSection.mermaidCodeBlocks = mermaidCodeBlocks;
 
@@ -31,6 +36,7 @@ async function createPostDetailElement(
   postDetail,
   mermaidCodeBlocks,
   vizCodeBlocks,
+  djangoCodeBlocks,
 ) {
   const postDetailSection = document.createElement("section");
   const contributorProfile = getContributorProfile(postDetail);
@@ -51,6 +57,9 @@ async function createPostDetailElement(
         ${mermaidCodeBlocks} <button class="absolute right-10" id="resetZoom">Reset Zoom</button>
         <button class="absolute right-10 top-10" id="downloadSVG" data-format="svg">Download SVG</button>
       </section>
+
+      <div class="django-container">
+      </div>
  
   `;
 
@@ -62,6 +71,13 @@ async function createPostDetailElement(
 
   const ERDBlock = postDetailSection.querySelector(".viz-placeholder");
   ERDBlock.innerHTML = svgString;
+
+  const models = new DjangoCodeBlocksEditor(
+    ".django-container",
+    djangoCodeBlocks,
+    true,
+  );
+  models.initialize();
 
   const editor = new CodeMirrorEditor(".language-viz", vizCodeBlocks[0]);
   editor.initialize().then(() => {

--- a/src/posts/001_django-blog-post-model.md
+++ b/src/posts/001_django-blog-post-model.md
@@ -48,6 +48,24 @@ class Comment(models.Model):
 
 ```
 
+```python
+# blog > models2.py
+
+from django.db import models
+
+
+
+class Comment(models.Model):
+    post = models.ForeignKey(Post, on_delete=models.CASCADE, related_name='comments')
+    content = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return f'Comment by {self.id} on {self.post}'
+
+```
+
 ```mermaid
 classDiagram
     class Blog_Post {

--- a/src/posts/001_django-blog-post-model.md
+++ b/src/posts/001_django-blog-post-model.md
@@ -66,6 +66,7 @@ class Comment(models.Model):
 
 ```
 
+<!--
 ```mermaid
 classDiagram
     class Blog_Post {
@@ -84,7 +85,7 @@ classDiagram
     }
     Blog_Post "1" -- "*" Blog_Comment : contains
 
-```
+``` -->
 
 ```viz
 digraph AppSchema {


### PR DESCRIPTION
- DetailView 수정
  - 새로 바뀐 기능과 디자인을 테스트하기 위해 01번 md를 또 수정했습니다. 덮어쓰셔도 무방합니다.
  - 이 기능들에 대한 종합적인 컨트리뷰트 가이드 항목 추가해둘 예정

- CodeMirrorEditor를 확장하여 Tab 형태의 DjangoModelEditor 추가
  - 블로그처럼 글을 쓰면서 중간중간에 형식에 맞게
  ```python 
  # blog > models.py
  
  # 여기에 내용
  
  ```
  - 이런식으로 코드블록을 추가하면, 블로그 글에서 코드블록들을 `복사` 해서 (분리하지는 않고)
  - 우측에 있는 탭 형 에디터에 모아 보기 쉽게 합니다.
  - 상단의 주석을 포함한 부분은 name이 되어 탭 제목으로 쓰입니다.
  - python codeblock 중 해당 형식의 주석이 있는 블록만 모으도록 했습니다.
 
 - markdownParser 리팩토링
   - 배열대신 -> 객체를 담은 배열로 리턴하게 함.
   - 내부 로직을 가독성 있게 수정
  
  - tab container를 위한 custom.css 수정

  