### PR TITLE
[gallery] ✨💄🐛 feat: 헤더, 푸터 추가, 다크모드, 간단한 반응형 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,26 +23,21 @@
       };
     </script>
   </head>
-  <body>
-    <header>
-      <nav>
-        <ul>
-          <li class="">
-            <a href="#">프로젝트 소개</a>
-          </li>
-          <li><a href="#">Django Model Gallery</a></li>
+  <body class="">
+    <section id="filter" class="dark:bg-gray-800 flex gap-x-2">
+      <button id="clearFilters" class="dark:text-white">Clear Filters</button>
+    </section>
 
-          <li><a href="./contribute/index.html">기여하기</a></li>
-          <li><a href="./license/index.html">라이센스</a></li>
-        </ul>
-      </nav>
-    </header>
-    <section id="filter" class="flex gap-x-2"></section>
-    <button id="clearFilters">Clear Filters</button>
-    <main></main>
-    <footer></footer>
+    <main class="dark:text-white"></main>
+
+    <footer
+      class="custom-footer bg-gray-800 text-white py-4 fixed bottom-0 w-full z-50 transition-opacity duration-300"
+    ></footer>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/viz.js/2.1.2/viz.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/viz.js/2.1.2/full.render.js"></script>
+    <script type="module" src="./src/js/components/Header.js"></script>
+    <script type="module" src="./src/js/components/Footer.js"></script>
     <script type="module" src="./src/js/main.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -30,10 +30,6 @@
 
     <main class="dark:text-white"></main>
 
-    <footer
-      class="custom-footer bg-gray-800 text-white py-4 fixed bottom-0 w-full z-50 transition-opacity duration-300"
-    ></footer>
-
     <script src="https://cdnjs.cloudflare.com/ajax/libs/viz.js/2.1.2/viz.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/viz.js/2.1.2/full.render.js"></script>
     <script type="module" src="./src/js/components/Header.js"></script>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,4 +1,8 @@
 /* Chrome, Safari, Opera 등의 Webkit 브라우저용 */
+body.dark {
+  background-color: #1f2937;
+}
+
 body::-webkit-scrollbar,
 .CodeMirror-scroll::-webkit-scrollbar {
   width: 10px;
@@ -46,13 +50,13 @@ body {
 .tab-button {
   padding: 5px 10px;
   margin-right: 5px;
-  background-color: #f1f1f1;
+  background-color: #888;
   border: none;
   cursor: pointer;
 }
 
 .tab-button.active {
-  background-color: #ccc;
+  background-color: #5e5e5e;
 }
 
 .editor-container {

--- a/src/js/components/ContributorProfile.js
+++ b/src/js/components/ContributorProfile.js
@@ -9,53 +9,50 @@ export function getContributorProfile({
 }) {
   const { name, social } = contributor;
   const { github, twitter } = social;
-
   const tagsHtml = tags
-    ? `<ul class="list-none flex gap-x-4">${tags
+    ? `<ul class="list-none flex flex-wrap gap-2">${tags
         .map(
           (tag) =>
-            `<li class="bg-emerald-900 rounded-xl px-2 py-0.5 text-white">${tag}</li>`
+            `<li class="bg-emerald-900 dark:bg-emerald-700 rounded-xl px-2 py-0.5 text-white text-sm">${tag}</li>`,
         )
         .join("")}</ul>`
     : "<p>없음</p>";
 
   return `
-    <article class="shadow-lg rounded-lg py-6 px-2 bg-emerald-500 ">
- 
-    <div class="max-w-4xl flex f-full mx-auto justify-between">
-      <div>
-        <h2 class="text-5xl font-semibold leading-tight">${title}</h2>
-        <p class="text-gray-600 font-semibold underline pt-3">${category}</p>
-        <time datetime="${date}" class="block text-sm text-gray-500">
-          ${date}
-        </time>
-        <div class="mt-2">
-          ${tagsHtml}
+    <article class="shadow-lg rounded-lg py-6 px-4 sm:px-6 lg:px-8 bg-emerald-500 dark:bg-emerald-800">
+      <div class="max-w-4xl mx-auto">
+        <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center">
+          <div class="mb-4 sm:mb-0">
+            <h2 class="text-3xl sm:text-4xl lg:text-5xl font-semibold leading-tight text-gray-800 dark:text-white">${title}</h2>
+            <p class="text-gray-600 dark:text-gray-400 font-semibold underline pt-3">${category}</p>
+            <time datetime="${date}" class="block text-sm text-gray-500 dark:text-gray-400">
+              ${date}
+            </time>
+            <div class="mt-4">
+              ${tagsHtml}
+            </div>
+          </div>
+          <div class="flex items-center justify-end">
+            <div class="flex items-center">
+              <h1 class="text-xl font-semibold pr-4 text-gray-800 dark:text-white">
+                기여자 :<br /><span class="text-2xl sm:text-3xl lg:text-4xl">${name}</span>
+              </h1>
+              <div class="flex flex-col gap-y-4">
+                <a href="${
+                  github ?? "#"
+                }" class="text-blue-500 hover:text-blue-700 bg-white dark:bg-gray-800 p-0.5 rounded-lg" target="_blank" rel="noopener noreferrer">
+                  <img src="./src/img/profile/github-logo.svg" class="w-8 h-8 sm:w-10 sm:h-10 rounded-full" alt="github-logo" />
+                </a>
+                <a href="${
+                  twitter ?? "#"
+                }" class="text-blue-500 hover:text-blue-700 bg-black dark:bg-gray-800 p-0.5 rounded-lg" target="_blank" rel="noopener noreferrer">
+                  <img src="./src/img/profile/x-logo.svg" class="w-8 h-8 sm:w-10 sm:h-10 rounded-full" alt="x-logo" />
+                </a>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-
-      <header class="flex items-end justify-end">
-      <h1 class="text-xl font-semibold pr-4"> 기여자 :<br /><span class="text-4xl">${name}</span></h1>
-      <div class="flex flex-col gap-y-4">
-        <a
-          href="${github ?? "#"}"
-          class="text-blue-500 hover:text-blue-700 bg-white p-0.5 rounded-lg"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-        <img src="./src/img/profile/github-logo.svg" class="w-10 h-10 rounded-full" alt="github-logo" />
-        </a>
-        <a
-          href="${twitter ?? "#"}"
-          class="text-blue-500 hover:text-blue-700 bg-black p-0.5 rounded-lg"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-        <img src="./src/img/profile/x-logo.svg" class="w-10 h-10 rounded-full" alt="x-logo" />
-        </a>
-      </div>
-    </header>
-    </div>
     </article>
   `;
 }

--- a/src/js/components/Footer.js
+++ b/src/js/components/Footer.js
@@ -1,0 +1,49 @@
+export function getFooter() {
+  const currentYear = new Date().getFullYear();
+  return `
+
+        <div class="max-w-4xl mx-auto px-4 flex flex-wrap justify-between items-center">
+          <div class="flex items-center">
+            <em class="text-2xl mr-2">&copy;</em>
+            <p class="text-sm">All rights reserved Django Model Gallery ${currentYear}</p>
+          </div>
+          <nav>
+            <ul class="flex space-x-4">
+              <li><a href="#" class="hover:text-gray-300">깃헙</a></li>
+              <li><a href="#" class="hover:text-gray-300">기여자들</a></li>
+              <li><a href="#" class="hover:text-gray-300">문의하기</a></li>
+            </ul>
+          </nav>
+        </div>
+
+    `;
+}
+
+const footerElement = document.createElement("footer");
+footerElement.classList.add(
+  "custom-footer",
+  "bg-gray-900",
+  "text-white",
+  "py-2",
+  "fixed",
+  "bottom-0",
+  "w-full",
+  "z-50",
+  "transition-opacity",
+  "duration-300",
+);
+footerElement.innerHTML = getFooter();
+document.body.appendChild(footerElement);
+
+function handleScroll() {
+  const scrollPosition = window.innerHeight + window.pageYOffset;
+  const documentHeight = document.documentElement.scrollHeight;
+  if (documentHeight <= window.innerHeight) {
+    footerElement.classList.add("opacity-100");
+  } else {
+    footerElement.classList.remove("opacity-100");
+  }
+}
+
+window.addEventListener("scroll", handleScroll);
+window.addEventListener("load", handleScroll);

--- a/src/js/components/Header.js
+++ b/src/js/components/Header.js
@@ -1,0 +1,61 @@
+import { NAV_ITEMS } from "../constants/navItems.js";
+import { throttle } from "../util/throttle.js";
+
+export function getHeader(navItems) {
+  const navItemsHtml = navItems
+    .map(
+      ({ title, link }) =>
+        `<li><a href="${link}" class="text-white hover:text-gray-200">${title}</a></li>`,
+    )
+    .join("");
+
+  return `
+    <nav class="max-w-4xl mx-auto px-4">
+      <ul class="flex flex-wrap justify-center sm:justify-end space-x-4">
+        <li><a href="/" class="text-white hover:text-gray-200 basis-6/12">Home</a></li>
+        <button class="theme-toggle-button">다크모드</button>
+        ${navItemsHtml}
+      </ul>
+    </nav>
+  `;
+}
+
+const headerElement = document.createElement("header");
+headerElement.classList.add(
+  "custom-header",
+  "bg-emerald-500",
+  "dark:bg-emerald-800",
+  "py-4",
+  "sticky",
+  "top-0",
+  "left-0",
+  "right-0",
+  "transition-transform",
+  "duration-300",
+  "ease-in-out",
+  "transform",
+  "z-50",
+);
+headerElement.innerHTML = getHeader(NAV_ITEMS);
+document.body.insertBefore(headerElement, document.body.firstElementChild);
+
+let lastScrollTop = 0;
+let isHeaderVisible = true;
+
+window.addEventListener(
+  "scroll",
+  throttle(function () {
+    const currentScrollTop =
+      window.pageYOffset || document.documentElement.scrollTop;
+    if (currentScrollTop > lastScrollTop && isHeaderVisible) {
+      // 스크롤을 아래로 내릴 때
+      headerElement.classList.add("-translate-y-full");
+      isHeaderVisible = false;
+    } else if (currentScrollTop < lastScrollTop && !isHeaderVisible) {
+      // 스크롤을 위로 올릴 때
+      headerElement.classList.remove("-translate-y-full");
+      isHeaderVisible = true;
+    }
+    lastScrollTop = currentScrollTop;
+  }, 200),
+);

--- a/src/js/constants/navItems.js
+++ b/src/js/constants/navItems.js
@@ -1,0 +1,18 @@
+export const NAV_ITEMS = [
+  {
+    title: "프로젝트 소개",
+    link: "#",
+  },
+  {
+    title: "Django Model Gallery",
+    link: "#",
+  },
+  {
+    title: "기여하기",
+    link: "./contribute/index.html",
+  },
+  {
+    title: "라이센스",
+    link: "./license/index.html",
+  },
+];

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -3,7 +3,7 @@ import { initializeTheme } from "./util/initializeTheme.js";
 import { filterButtons } from "./constants/filterList.js";
 import MainFilterManager from "./service/MainFilterManager.js";
 import { fetchPosts } from "./util/fetchPost.js";
-import { applySavedTheme } from "./util/toggleTheme.js";
+import { applySavedTheme, toggleTheme } from "./util/toggleTheme.js";
 import { createPostDetailView } from "./views/postDetailView.js";
 import { createPostView } from "./views/postListView.js";
 
@@ -56,10 +56,9 @@ async function renderMainContent() {
 
 applySavedTheme();
 
-// darkmode toggle button 입니다.
-// document
-//   .getElementById("theme-toggle-button")
-//   .addEventListener("click", toggleTheme);
+document
+  .querySelector(".theme-toggle-button")
+  .addEventListener("click", toggleTheme);
 
 initializeTheme();
 renderMainContent();

--- a/src/js/util/markdownParser.js
+++ b/src/js/util/markdownParser.js
@@ -44,9 +44,14 @@ export function parseMarkdown(markdownContent) {
         }
         if (infostring.startsWith("python")) {
           const lines = code.split("\n");
-          const djangoCodeName = lines[0].trim().replace(/^#\s*/, "");
-          const djangoCode = lines.slice(1).join("\n");
-          codeBlocks.django.push({ name: djangoCodeName, code: djangoCode });
+          const djangoCodeName = lines[0].trim();
+          if (djangoCodeName.startsWith("#")) {
+            const djangoCode = lines.slice(1).join("\n");
+            codeBlocks.django.push({
+              name: djangoCodeName.replace(/^#\s*/, ""),
+              code: djangoCode,
+            });
+          }
         }
         return `<pre><code class="${infostring}">${code}</code></pre>`;
       },

--- a/src/js/views/postDetailView.js
+++ b/src/js/views/postDetailView.js
@@ -46,7 +46,7 @@ async function createPostDetailElement(
     `
  
     <section class="flex flex-col md:flex-row w-full h-lvh items-center justify-center">
-      <article class="prose 2xl:prose-xl w-full md:w-1/2 h-full overflow-y-auto px-10 pt-5">${htmlContent}</article>
+      <article class="prose 2xl:prose-xl w-full md:w-1/2 h-full overflow-y-auto px-10 pt-5 bg-zinc-400">${htmlContent}</article>
 
 
       <div class="flex flex-col relative">


### PR DESCRIPTION
- 전역 스타일 다크모드 배경 추가

- Header.js, Footer.js 제작
  - js로 제작했는데, jsx가 안되므로 현재 body의 첫번재 요소와 마지막 요소로 자동으로 렌더합니다.
  - 각각 body 하단에 script를 등록하면 가져와지니 추후 페이지 제작시 붙여넣으시기 바랍니다..
  
- Header 용 NavItem 옵션 Constants에 분리
  - 헤더에 주소 추가하고 싶으신 분들께서는 여기다 추가해주시면 되겠습니다.
 
 - 기존 컨트리뷰트 헤더에 다크모드 스타일 추가
   - 다크모드 및 반응형 스타일 추가
   - 근데 예시로 있는 tailwindCSS 코드 써야 되는데 라벨링해야겠습니다.
 
 - markdown parser에서 예외처리 추가
   - python code가 있는 tab을 분리할때의 예외를 빈 칸으로 처리했었는데, 예시코드를 보니 빈 칸이 없어서 렌더링 되는중...
   - 빈 칸이 아닐 경우도 커버하게 변경했습니다. ("#") 이 있는지 확인합니다.
   
 
 